### PR TITLE
chore(auth): temporarily disable Supabase auth and route root to dash…

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,16 +15,27 @@ import TermsOfService from "@/pages/terms-of-service";
 import NotFound from "@/pages/not-found";;
 import AuthRoot from "@/auth/AuthRoot";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
+import { useEffect } from "react";
+import { useLocation } from "wouter";
+
+function RedirectToDashboard() {
+  const [, setLocation] = useLocation();
+  useEffect(() => {
+    setLocation('/dashboard');
+  }, [setLocation]);
+  return null;
+}
 
 function Router() {
   return (
     <Switch>
-      <Route path="/" component={Landing} />
+      {/* Temporarily redirect root to dashboard */}
+      <Route path="/" component={RedirectToDashboard} />
       <Route path="/privacy-policy" component={PrivacyPolicy} />
       <Route path="/terms-of-service" component={TermsOfService} />
       <Route path="/auth" component={AuthRoot} />
       <Route path="/dashboard">
-        <ProtectedRoute><Layout><Dashboard /></Layout></ProtectedRoute>
+        <Layout><Dashboard /></Layout>
       </Route>
       <Route path="/library">
         <ProtectedRoute><Layout><Library /></Layout></ProtectedRoute>
@@ -35,8 +46,9 @@ function Router() {
       <Route path="/settings">
         <ProtectedRoute><Layout><Settings /></Layout></ProtectedRoute>
       </Route>
+      {/* Fallback: redirect any unknown route to dashboard */}
       <Route>
-        <Layout><NotFound /></Layout>
+        <RedirectToDashboard />
       </Route>
     </Switch>
   );

--- a/client/src/components/auth/ProtectedRoute.tsx
+++ b/client/src/components/auth/ProtectedRoute.tsx
@@ -1,29 +1,28 @@
 
 import { ReactNode } from 'react'
-import { useAuth } from '@/contexts/AuthContext'
-import { useLocation } from 'wouter'
-import { Loader2 } from 'lucide-react'
+// import { useAuth } from '@/contexts/AuthContext'
+// import { useLocation } from 'wouter'
+// import { Loader2 } from 'lucide-react'
 
 interface ProtectedRouteProps {
   children: ReactNode
 }
 
 export const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
-  const { user, loading } = useAuth()
-  const [, setLocation] = useLocation()
-
-  if (loading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <Loader2 className="w-8 h-8 animate-spin text-primary" />
-      </div>
-    )
-  }
-
-  if (!user) {
-    setLocation('/auth')
-    return null
-  }
-
+  // TEMPORARY: Auth protection disabled to allow app usage without login.
+  // To re-enable, uncomment the block below and the imports above.
+  // const { user, loading } = useAuth()
+  // const [, setLocation] = useLocation()
+  // if (loading) {
+  //   return (
+  //     <div className="min-h-screen flex items-center justify-center">
+  //       <Loader2 className="w-8 h-8 animate-spin text-primary" />
+  //     </div>
+  //   )
+  // }
+  // if (!user) {
+  //   setLocation('/auth')
+  //   return null
+  // }
   return <>{children}</>
 }

--- a/client/src/lib/supabase.ts
+++ b/client/src/lib/supabase.ts
@@ -8,15 +8,44 @@ console.log('Environment variables check:');
 console.log('VITE_SUPABASE_URL:', supabaseUrl ? 'Found' : 'Not found');
 console.log('VITE_SUPABASE_ANON_KEY:', supabaseAnonKey ? 'Found' : 'Not found');
 
+let supabase: any
+
 if (!supabaseUrl || !supabaseAnonKey) {
-  console.error('Available env vars:', Object.keys(import.meta.env));
-  throw new Error('Missing Supabase environment variables')
+  console.warn('[Supabase] Missing environment variables. Using mock client. Authentication is disabled in this mode.')
+
+  const mockAuth = {
+    getSession: async () => ({ data: { session: null } }),
+    onAuthStateChange: (_cb: any) => ({ data: { subscription: { unsubscribe: () => {} } } }),
+    signUp: async () => ({ data: null, error: { message: 'Auth disabled' } }),
+    signInWithPassword: async () => ({ data: null, error: { message: 'Auth disabled' } }),
+    signOut: async () => ({ error: null }),
+    resetPasswordForEmail: async () => ({ data: null, error: { message: 'Auth disabled' } }),
+    updateUser: async () => ({ data: null, error: { message: 'Auth disabled' } }),
+    signInWithOAuth: async () => ({ data: null, error: { message: 'Auth disabled' } }),
+    setSession: async () => ({ data: null, error: { message: 'Auth disabled' } })
+  }
+
+  const mockFrom = (_table?: string) => ({
+    select: (_cols?: string) => ({
+      eq: (_col: string, _val: any) => ({
+        single: async () => ({ data: null, error: null })
+      })
+    }),
+    upsert: async (_payload: any) => ({ data: null, error: null })
+  })
+
+  supabase = {
+    auth: mockAuth,
+    from: mockFrom
+  }
+} else {
+  supabase = createClient(supabaseUrl, supabaseAnonKey, {
+    auth: {
+      autoRefreshToken: true,
+      persistSession: true,
+      detectSessionInUrl: true
+    }
+  })
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
-  auth: {
-    autoRefreshToken: true,
-    persistSession: true,
-    detectSessionInUrl: true
-  }
-})
+export { supabase }


### PR DESCRIPTION
…board

- Bypass auth guard in `client/src/components/auth/ProtectedRoute.tsx`; it now always renders children.

- Swap Supabase client for a mock when env vars are missing in `client/src/lib/supabase.ts`, avoiding startup crashes. Auth calls return neutral/mock responses.

- Redirect `/` and unknown routes to `/dashboard` via `RedirectToDashboard` in `client/src/App.tsx`; remove guard from `/dashboard` to load immediately.

Re-enable later: uncomment `ProtectedRoute.tsx`, set Supabase env vars, and restore routes if needed. Note: auth flows won’t function while mock is active.